### PR TITLE
Show transaction status as a label (more informative) than a number

### DIFF
--- a/Block/Info/AbstractInfo.php
+++ b/Block/Info/AbstractInfo.php
@@ -27,6 +27,11 @@ abstract class AbstractInfo extends \Magento\Payment\Block\Info
     protected $transactionRepository;
 
     /**
+     * @var array
+     */
+    protected $transactionStatus;
+
+    /**
      * Constructor
      *
      * @param Template\Context $context
@@ -35,12 +40,14 @@ abstract class AbstractInfo extends \Magento\Payment\Block\Info
     public function __construct(
         \PayEx\Payments\Helper\Data $payexHelper,
         \Magento\Sales\Api\TransactionRepositoryInterface $transactionRepository,
+        \PayEx\Payments\Model\Config\Source\TransactionStatus $transactionStatus,
         Template\Context $context,
         array $data = []
     )
     {
         parent::__construct($context, $data);
         $this->payexHelper = $payexHelper;
+        $this->transactionStatus = $transactionStatus->toOptionArray();
         $this->transactionRepository = $transactionRepository;
     }
 
@@ -81,6 +88,12 @@ abstract class AbstractInfo extends \Magento\Payment\Block\Info
                     foreach ($this->transactionFields as $description => $list) {
                         foreach ($list as $key => $value) {
                             if (isset($transaction_data[$value])) {
+                                if ($value == 'transactionStatus') {
+                                    if (isset($this->transactionStatus[$transaction_data[$value]]) && isset($this->transactionStatus[$transaction_data[$value]]['value'])) {
+                                        $transaction_data[$value] = $this->transactionStatus[$transaction_data[$value]]['value'];
+                                    }
+                                }
+
                                 $result[$description] = $transaction_data[$value];
                             }
                         }

--- a/Model/Config/Source/TransactionStatus.php
+++ b/Model/Config/Source/TransactionStatus.php
@@ -1,0 +1,23 @@
+﻿<?php
+
+namespace PayEx\Payments\Model\Config\Source;
+
+class TransactionStatus implements \Magento\Framework\Option\ArrayInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function toOptionArray()
+    {
+        /* Transaction statuses: 0=Sale, 1=Initialize, 2=Credit, 3=Authorize, 4=Cancel, 5=Failure, 6=Capture */
+        return  [
+            ['value' => 0, 'label' => __('Sale')],
+            ['value' => 1, 'label' => __('Initialize')],
+            ['value' => 2, 'label' => __('Credit')],
+            ['value' => 3, 'label' => __('Authorize')],
+            ['value' => 4, 'label' => __('Cancel')],
+            ['value' => 5, 'label' => __('Failure')],
+            ['value' => 6, 'label' => __('Capture')],
+        ];
+    }
+}


### PR DESCRIPTION
These changes are intended for displaying transaction status as a text label instead of a number, which is more informative