### PR TITLE
Use bcmath to avoid a problem with round

### DIFF
--- a/Model/Method/Bankdebit.php
+++ b/Model/Method/Bankdebit.php
@@ -271,9 +271,9 @@ class Bankdebit extends \PayEx\Payments\Model\Method\AbstractMethod
                     'itemDescription4' => '',
                     'itemDescription5' => '',
                     'quantity' => $item['qty'],
-                    'amount' => (int)(100 * $item['price_with_tax']), //must include tax
-                    'vatPrice' => (int)(100 * $item['tax_price']),
-                    'vatPercent' => (int)(100 * $item['tax_percent'])
+                    'amount' => bcmul(100, $item['price_with_tax']), //must include tax
+                    'vatPrice' => bcmul(100, $item['tax_price']),
+                    'vatPercent' => bcmul(100, $item['tax_percent'])
                 ];
 
                 $result = $this->payexHelper->getPx()->AddSingleOrderLine2($params);

--- a/Model/Method/Cc.php
+++ b/Model/Method/Cc.php
@@ -226,9 +226,9 @@ class Cc extends \PayEx\Payments\Model\Method\AbstractMethod
                     'itemDescription4' => '',
                     'itemDescription5' => '',
                     'quantity' => $item['qty'],
-                    'amount' => (int)(100 * $item['price_with_tax']), //must include tax
-                    'vatPrice' => (int)(100 * $item['tax_price']),
-                    'vatPercent' => (int)(100 * $item['tax_percent'])
+                    'amount' => bcmul(100, $item['price_with_tax']), //must include tax
+                    'vatPrice' => bcmul(100, $item['tax_price']),
+                    'vatPercent' => bcmul(100, $item['tax_percent'])
                 ];
 
                 $result = $this->payexHelper->getPx()->AddSingleOrderLine2($params);

--- a/Model/Method/Evc.php
+++ b/Model/Method/Evc.php
@@ -140,9 +140,9 @@ class Evc extends \PayEx\Payments\Model\Method\Cc
                     'itemDescription4' => '',
                     'itemDescription5' => '',
                     'quantity' => $item['qty'],
-                    'amount' => (int)(100 * $item['price_with_tax']), //must include tax
-                    'vatPrice' => (int)(100 * $item['tax_price']),
-                    'vatPercent' => (int)(100 * $item['tax_percent'])
+                    'amount' => bcmul(100, $item['price_with_tax']), //must include tax
+                    'vatPrice' => bcmul(100, $item['tax_price']),
+                    'vatPercent' => bcmul(100, $item['tax_percent'])
                 ];
 
                 $result = $this->payexHelper->getPx()->AddSingleOrderLine2($params);

--- a/Model/Method/Gc.php
+++ b/Model/Method/Gc.php
@@ -140,9 +140,9 @@ class Gc extends \PayEx\Payments\Model\Method\Cc
                     'itemDescription4' => '',
                     'itemDescription5' => '',
                     'quantity' => $item['qty'],
-                    'amount' => (int)(100 * $item['price_with_tax']), //must include tax
-                    'vatPrice' => (int)(100 * $item['tax_price']),
-                    'vatPercent' => (int)(100 * $item['tax_percent'])
+                    'amount' => bcmul(100, $item['price_with_tax']), //must include tax
+                    'vatPrice' => bcmul(100, $item['tax_price']),
+                    'vatPercent' => bcmul(100, $item['tax_percent'])
                 ];
 
                 $result = $this->payexHelper->getPx()->AddSingleOrderLine2($params);

--- a/Model/Method/MobilePay.php
+++ b/Model/Method/MobilePay.php
@@ -143,9 +143,9 @@ class MobilePay extends \PayEx\Payments\Model\Method\Cc
                     'itemDescription4' => '',
                     'itemDescription5' => '',
                     'quantity' => $item['qty'],
-                    'amount' => (int)(100 * $item['price_with_tax']), //must include tax
-                    'vatPrice' => (int)(100 * $item['tax_price']),
-                    'vatPercent' => (int)(100 * $item['tax_percent'])
+                    'amount' => bcmul(100, $item['price_with_tax']), //must include tax
+                    'vatPrice' => bcmul(100, $item['tax_price']),
+                    'vatPercent' => bcmul(100, $item['tax_percent'])
                 ];
 
                 $result = $this->payexHelper->getPx()->AddSingleOrderLine2($params);

--- a/Model/Method/Swish.php
+++ b/Model/Method/Swish.php
@@ -142,9 +142,9 @@ class Swish extends \PayEx\Payments\Model\Method\Cc
                     'itemDescription4' => '',
                     'itemDescription5' => '',
                     'quantity' => $item['qty'],
-                    'amount' => (int)(100 * $item['price_with_tax']), //must include tax
-                    'vatPrice' => (int)(100 * $item['tax_price']),
-                    'vatPercent' => (int)(100 * $item['tax_percent'])
+                    'amount' => bcmul(100, $item['price_with_tax']), //must include tax
+                    'vatPrice' => bcmul(100, $item['tax_price']),
+                    'vatPercent' => bcmul(100, $item['tax_percent'])
                 ];
 
                 $result = $this->payexHelper->getPx()->AddSingleOrderLine2($params);

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
   ],
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0",
+    "ext-bc":"*",
     "magento/module-config": "*",
     "magento/module-store": "*",
     "magento/module-checkout": "*",


### PR DESCRIPTION
Casting the result of floating point operations to integer value might result in unpredictable behaviour:

$ php -r "var_dump((int)(100 * 280.9));"
Command line code:1:
int(28089) 

To avoid this problem it makes sense to use bc math module
